### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @blamelesshq/incident


### PR DESCRIPTION
Add CODEOWNERS for git PRs. 

incidental team was added as initial owners for this repo.