### PR TITLE
INC-708 Updating release variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
     with:
       release-notes: true
       setup-go-version-file: ".go-version"
-      product-version: "${{ github.ref_name }}"
+      git-ref: "${{ github.ref }}"


### PR DESCRIPTION
- `product-version` isn't supported in `hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v2`
- Specifying the git ref to release