### PR TITLE
INC-767 Removing API readiness warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Blameless Terraform Provider
 
-:warning: The API supporting this provider is not released yet :warning:
-
 This provider allow use Terraform to handle Blameless resources.
 
 - [Documentation](https://registry.terraform.io/providers/blamelesshq/blameless/latest/docs)


### PR DESCRIPTION
Since the service that supports this provider has been fully released, we no longer need the warning about the API not being ready.