### PR TITLE
ENG-1621 Updating documentation and examples for Incident Type Custom Channel Format

### DIFF
--- a/docs/resources/incident_type.md
+++ b/docs/resources/incident_type.md
@@ -29,7 +29,7 @@ resource "blameless_incident_type" "incident_type_security" {
 
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s0-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
 
     # Slack Notifications
     slack_invited_users = [
@@ -100,21 +100,21 @@ resource "blameless_incident_type" "incident_type_security" {
     severity               = 1
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s1-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
   }
 
   severity_settings {
     severity               = 2
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s2-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
   }
 
   severity_settings {
     severity               = 3
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s3-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
   }
 }
 ```

--- a/examples/resources/blameless_incident_type/resource.tf
+++ b/examples/resources/blameless_incident_type/resource.tf
@@ -14,7 +14,7 @@ resource "blameless_incident_type" "incident_type_security" {
 
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s0-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
 
     # Slack Notifications
     slack_invited_users = [
@@ -85,20 +85,20 @@ resource "blameless_incident_type" "incident_type_security" {
     severity               = 1
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s1-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
   }
 
   severity_settings {
     severity               = 2
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s2-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
   }
 
   severity_settings {
     severity               = 3
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s3-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
   }
 }

--- a/modules/incident_type_security.tf
+++ b/modules/incident_type_security.tf
@@ -14,7 +14,7 @@ resource "blameless_incident_type" "incident_type_security" {
 
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s0-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
 
     slack_invited_users = [
       "@dillon"
@@ -82,6 +82,6 @@ resource "blameless_incident_type" "incident_type_security" {
     severity               = 1
     incident_naming_scheme = "custom"
     require_dash_separator = false
-    custom_channel_format  = "s1-{incident.name}"
+    custom_channel_format  = "{{incident.id}}-{{incident.title}}-{{incident.severity}}-{{incident.status}}-{{incident.created}}"
   }
 }


### PR DESCRIPTION
The current examples and documentation show the variables in the `custom_channel_format` field in the `blameless_incident_type` resource with only one pair of braces. The correct format is to use two pairs of braces.

The currently available variables are now used in the examples as well.